### PR TITLE
MAGECLOUD-4980: Pagebuilder patches fail CE functional tests

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -289,4 +289,5 @@
       ">=2.3.2-p1 <2.3.3": "PB-322__fix_pagebuilder_module__2.3.2-p1.patch",
       "2.3.3": "PB-323__fix_pagebuilder_module__2.3.3.patch"
     }
+  }
 }

--- a/patches.json
+++ b/patches.json
@@ -288,5 +288,5 @@
       "2.3.2": "PB-320__fix_pagebuilder_module__2.3.2.patch",
       ">=2.3.2-p1 <2.3.3": "PB-322__fix_pagebuilder_module__2.3.2-p1.patch",
       "2.3.3": "PB-323__fix_pagebuilder_module__2.3.3.patch"
-    },
+    }
 }

--- a/patches.json
+++ b/patches.json
@@ -202,12 +202,6 @@
       "2.3.1": "MAGECLOUD-3392__reduce_q-ty_of_error_report_files__2.3.1.patch",
       ">=2.3.2 <2.3.4": "MAGECLOUD-3392__reduce_q-ty_of_error_report_files__2.3.2.patch"
     },
-    "Fix pagebuilder module": {
-      "2.3.1": "PB-319__fix_pagebuilder_module__2.3.1.patch",
-      "2.3.2": "PB-320__fix_pagebuilder_module__2.3.2.patch",
-      ">=2.3.2-p1 <2.3.3": "PB-322__fix_pagebuilder_module__2.3.2-p1.patch",
-      "2.3.3": "PB-323__fix_pagebuilder_module__2.3.3.patch"
-    },
     "Fix XSS in order history": {
       "2.2.0 - 2.2.6": "PRODSECBUG-2233__fix_xss_in_order_history__2.2.0.patch",
       "2.2.7 - 2.2.8": "PRODSECBUG-2233__fix_xss_in_order_history__2.2.7.patch",
@@ -287,5 +281,12 @@
     "Fix wrong namespace": {
       "3.2.0": "MAGECLOUD-4407__fix_namespace_vertex_tax__3.2.0.patch"
     }
-  }
+  },
+  "magento/magento2-ee-base": {
+    "Fix pagebuilder module": {
+      "2.3.1": "PB-319__fix_pagebuilder_module__2.3.1.patch",
+      "2.3.2": "PB-320__fix_pagebuilder_module__2.3.2.patch",
+      ">=2.3.2-p1 <2.3.3": "PB-322__fix_pagebuilder_module__2.3.2-p1.patch",
+      "2.3.3": "PB-323__fix_pagebuilder_module__2.3.3.patch"
+    },
 }


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Pagebuilder patches fail on CE functional tests due to PB module not being present

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud-patches#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. MAGECLOUD-4980

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Confirm any PB patches still apply.
2. Review automated functional tests for CE after merge.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
