### PR TITLE
MAGECLOUD-5127: Update Constraints for Magento 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,11 @@
         "php": "^7.0",
         "ext-json": "*",
         "composer/composer": "@stable",
+        "composer/semver": "^1.5",
         "symfony/config": "^3.3||^4.3",
         "symfony/console": "^2.6||^4.0",
         "symfony/dependency-injection": "^3.3||^4.3",
         "symfony/process": "^2.1||^4.1"
-    },
-    "conflict": {
-        "symfony/process": "^4.2"
     },
     "require-dev": {
         "phpmd/phpmd": "@stable",

--- a/config/services.xml
+++ b/config/services.xml
@@ -13,5 +13,6 @@
         <service id="Magento\CloudPatches\Command\Patch\ManagerException" autowire="false"/>
         <service id="Magento\CloudPatches\Patch\ApplierException" autowire="false"/>
         <service id="Magento\CloudPatches\Filesystem\FileNotFoundException" autowire="false"/>
+        <service id="Magento\CloudPatches\Shell\PackageNotFoundException" autowire="false"/>
     </services>
 </container>

--- a/src/Shell/PackageNotFoundException.php
+++ b/src/Shell/PackageNotFoundException.php
@@ -10,7 +10,7 @@ namespace Magento\CloudPatches\Shell;
 use Magento\CloudPatches\App\GenericException;
 
 /**
- * Exception if a composer package could not be found for some reason (eg, symfony/process)
+ * Exception if a Composer package could not be found for some reason (e.g., symfony/process).
  */
 class PackageNotFoundException extends GenericException
 {

--- a/src/Shell/PackageNotFoundException.php
+++ b/src/Shell/PackageNotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CloudPatches\Shell;
+
+use Magento\CloudPatches\App\GenericException;
+
+/**
+ * Exception if symfony/process package could not be found for some reason
+ */
+class PackageNotFoundException extends GenericException
+{
+}

--- a/src/Shell/PackageNotFoundException.php
+++ b/src/Shell/PackageNotFoundException.php
@@ -10,7 +10,7 @@ namespace Magento\CloudPatches\Shell;
 use Magento\CloudPatches\App\GenericException;
 
 /**
- * Exception if symfony/process package could not be found for some reason
+ * Exception if a composer package could not be found for some reason (eg, symfony/process)
  */
 class PackageNotFoundException extends GenericException
 {

--- a/src/Shell/ProcessFactory.php
+++ b/src/Shell/ProcessFactory.php
@@ -20,7 +20,7 @@ use Symfony\Component\Process\Process;
  */
 class ProcessFactory
 {
-    private const ARRAY_PARAM_MIN_VERSION = '3.3.0';
+    const ARRAY_PARAM_MIN_VERSION = '3.3.0';
 
     /**
      * @var DirectoryList

--- a/src/Shell/ProcessFactory.php
+++ b/src/Shell/ProcessFactory.php
@@ -7,6 +7,9 @@ declare(strict_types=1);
 
 namespace Magento\CloudPatches\Shell;
 
+use Composer\Composer;
+use Composer\Repository\RepositoryInterface;
+use Composer\Semver\Comparator;
 use Magento\CloudPatches\Filesystem\DirectoryList;
 use Symfony\Component\Process\Process;
 
@@ -17,17 +20,25 @@ use Symfony\Component\Process\Process;
  */
 class ProcessFactory
 {
+    private const ARRAY_PARAM_MIN_VERSION = '3.3.0';
+
     /**
      * @var DirectoryList
      */
     private $directoryList;
 
     /**
+     * @var RepositoryInterface
+     */
+    private $repository;
+
+    /**
      * @param DirectoryList $directoryList
      */
-    public function __construct(DirectoryList $directoryList)
+    public function __construct(DirectoryList $directoryList, Composer $composer)
     {
         $this->directoryList = $directoryList;
+        $this->repository = $composer->getLocker()->getLockedRepository();
     }
 
     /**
@@ -37,8 +48,22 @@ class ProcessFactory
     public function create(array $cmd): Process
     {
         return new Process(
-            implode(' ', $cmd),
+            $this->processSupportsArrayParam() ? $cmd : implode(' ', $cmd),
             $this->directoryList->getMagentoRoot()
         );
+    }
+
+    /**
+     * Test if symfony/process is current enough to support an array for its first parameter.
+     */
+    private function processSupportsArrayParam(): bool
+    {
+        $package = $this->repository->findPackage('symfony/process', '*');
+
+        if ($package === null) {
+            throw new PackageNotFoundException('Could not find symfony/process package.');
+        }
+
+        return Comparator::greaterThanOrEqualTo($package->getVersion(), self::ARRAY_PARAM_MIN_VERSION);
     }
 }


### PR DESCRIPTION
### Description

Magento 2.4 bumps the minimum version of symfony/* packages to 4.4. This removes our "conflict" with `symfony/process` 4.2+ and ensures the correct parameter types are passed to that object.

### Fixed Issues (if relevant)

[MAGECLOUD-5127](https://magento2.atlassian.net/browse/MAGECLOUD-5127)

### Manual testing scenarios

No manual tests, just make sure everything installs as expected.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

Related PR into ece-tools https://github.com/magento/ece-tools/pull/675

releasenote
**Updated the `composer.json` constraints for compatibility with upcoming Magento releases**–Updated the `symfony` and `semver` version constraints for compatibility with Magento 2.4 and later.