### PR TITLE
MC-31387: Paypal issue with region on 2.3.4

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -238,6 +238,9 @@
     },
     "Fix for multi-site configuration issue": {
       "2.2.4": "MAGETWO-92926__fix_for_multi-site_configuration_issue__2.2.4.patch"
+    },
+    "Fix PayPal issue with region": {
+      "2.3.4": "MC-31387__fix_paypal_issue_with_region__2.3.4.patch"
     }
   },
   "monolog/monolog": {

--- a/patches/MC-31387__fix_paypal_issue_with_region__2.3.4.patch
+++ b/patches/MC-31387__fix_paypal_issue_with_region__2.3.4.patch
@@ -1,0 +1,67 @@
+diff -Nuar a/vendor/magento/module-paypal/Model/Api/Nvp.php b/vendor/magento/module-paypal/Model/Api/Nvp.php
+--- a/vendor/magento/module-paypal/Model/Api/Nvp.php
++++ b/vendor/magento/module-paypal/Model/Api/Nvp.php
+@@ -1512,17 +1512,17 @@
+         }
+         // attempt to fetch region_id from directory
+         if ($address->getCountryId() && $address->getRegion()) {
+-            $regions = $this->_countryFactory->create()->loadByCode(
+-                $address->getCountryId()
+-            )->getRegionCollection()->addRegionCodeOrNameFilter(
+-                $address->getRegion()
+-            )->setPageSize(
+-                1
+-            );
++            $regions = $this->_countryFactory->create()
++                ->getRegionCollection()
++                ->addCountryFilter($address->getCountryId())
++                ->addRegionCodeOrNameFilter($address->getRegion())
++                ->setPageSize(1);
+             $regionItems = $regions->getItems();
+-            $region = array_shift($regionItems);
+-            $address->setRegionId($region->getId());
+-            $address->setExportedKeys(array_merge($address->getExportedKeys(), ['region_id']));
++            if (count($regionItems)) {
++                $region = array_shift($regionItems);
++                $address->setRegionId($region->getId());
++                $address->setExportedKeys(array_merge($address->getExportedKeys(), ['region_id']));
++            }
+         }
+     }
+ 
+@@ -1624,7 +1624,7 @@
+             case 'year':
+                 return 'Year';
+             default:
+-                break;
++                return '';
+         }
+     }
+ 
+@@ -1653,7 +1653,7 @@
+             case 'active':
+                 return 'Active';
+             default:
+-                break;
++                return '';
+         }
+     }
+ 
+@@ -1694,7 +1694,7 @@
+             case 'Voided':
+                 return \Magento\Paypal\Model\Info::PAYMENTSTATUS_VOIDED;
+             default:
+-                break;
++                return null;
+         }
+     }
+ 
+@@ -1712,7 +1712,7 @@
+             case \Magento\Paypal\Model\Pro::PAYMENT_REVIEW_DENY:
+                 return 'Deny';
+             default:
+-                break;
++                return null;
+         }
+     }
+ 


### PR DESCRIPTION
### Description
[MC-31387](https://jira.corp.magento.com/browse/MC-31387)

### Fixed Issues (if relevant)
Can't place an order using PayPal Express Checkout payment and UK shipping address


### Manual testing scenarios
https://jira.corp.magento.com/browse/MC-11165

1. Enable PayPal Express Checkout
2. Add product to the cart as a guest
3. Go to checkout
4. Enter your shipping address to be in UK for example and enter some state, I used Nottinghamshire (https://jira.corp.magento.com/browse/MAGETWO-75905)
5. Place order, confirm from Paypal side
6. Order is placed successfully (without patch you will get error 500)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

releasenote
**[PayPal Express Checkout issue with region patch for Magento v2.3.4](https://magento.com/tech-resources/download#download2353)**-Updated the {{site.data.var.mcp}} package to add this critical patch, published on February 12, 2020. This patch resolves an issue that affects orders placed with PayPal Express Checkout where the shipping address for the order specifies a country region that has been manually entered into the text field rather than selected from the drop-down menu on the Shipping page. See [Apply patches]({{site.baseurl}}/cloud/project/project-patch.html).