### PR TITLE
Remove conflict from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,6 @@
         "symfony/dependency-injection": "^3.3||^4.3",
         "symfony/process": "^2.1||^4.1"
     },
-    "conflict": {
-        "symfony/process": "^4.2"
-    },
     "require-dev": {
         "phpmd/phpmd": "@stable",
         "phpunit/phpunit": "^6.2",


### PR DESCRIPTION
### Description

Remove `"conflict"` from `composer.json` as it isn't accurate and breaks compatibility with Magento 2.4.

This was already done in `develop` previously but was lost after a merge.

### Fixed Issues (if relevant)

MAGECLOUD-5127

### Manual testing scenarios

None, already tested.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

releasenote
See PR #19.