### PR TITLE
Fix JSON syntax error on Magento_Amqp patches

### DIFF
--- a/patches/MAGETWO-99902__pass_store_view_scope_in_async_web_api__2.3.1.patch
+++ b/patches/MAGETWO-99902__pass_store_view_scope_in_async_web_api__2.3.1.patch
@@ -234,7 +234,7 @@ diff -Nuar a/vendor/magento/module-amqp/composer.json b/vendor/magento/module-am
          "php": "~7.1.3||~7.2.0"
      },
 +    "suggest": {
-+        "magento/module-asynchronous-operations": "*",
++        "magento/module-asynchronous-operations": "*"
 +    },
      "type": "magento2-module",
      "license": [

--- a/patches/MAGETWO-99902__pass_store_view_scope_in_async_web_api__2.3.2.patch
+++ b/patches/MAGETWO-99902__pass_store_view_scope_in_async_web_api__2.3.2.patch
@@ -234,7 +234,7 @@ diff -Nuar a/vendor/magento/module-amqp/composer.json b/vendor/magento/module-am
          "php": "~7.1.3||~7.2.0"
      },
 +    "suggest": {
-+        "magento/module-asynchronous-operations": "*",
++        "magento/module-asynchronous-operations": "*"
 +    },
      "type": "magento2-module",
      "license": [


### PR DESCRIPTION
### Description
Last object in JSON must not have a 'comma'.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
 