### PR TITLE
MAGECLOUD-5359: Patches 1.0.2 fail on magento version 2.1.4 with php 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "composer/composer": "@stable",
         "composer/semver": "^1.5",
         "symfony/config": "^3.3||^4.4",
-        "symfony/console": "^2.8||^4.0",
+        "symfony/console": "^2.6||^4.0",
         "symfony/dependency-injection": "^3.3||^4.3",
         "symfony/process": "^2.1||^4.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/magento-cloud-patches",
     "description": "Provides critical fixes for Magento 2 Enterprise Edition",
     "type": "magento2-component",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "license": "OSL-3.0",
     "require": {
         "php": "^7.0",


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud-patches#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://magento2.atlassian.net/browse/MAGECLOUD-5359

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

releasenote
**Compatibility fix for `ece-tools` package**–Updated constraints in `composer.json` for compatibility with `ece-tools` 2002.0.22 and later 2002.0.x releases.