### PR TITLE
MCLOUD-3025: Sitemap generation warnings

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -234,12 +234,12 @@
     "Hold deployment config after reading from file": {
       ">=2.3.3 <2.3.6": "MCLOUD-5650__hold_deployment_config_after_reading_from_file.patch"
     },
-    "Sitemap Generation Warnings": {
-      ">=2.3.0 <2.3.5": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
-    },
     "Pagination Not working - product_list_limit=all": {
       ">=2.3.2 <2.3.4": "MCLOUD-5684__pagination_not_working_product_list_limit_all__2.3.2.patch",
       ">=2.3.4 <2.4.0": "MCLOUD-5684__pagination_not_working_product_list_limit_all__2.3.4.patch"
+    },
+    "Sitemap Generation Warnings": {
+      ">=2.3.0 <2.3.5": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
     }
   },
   "magento/module-paypal": {

--- a/patches.json
+++ b/patches.json
@@ -232,7 +232,7 @@
       ">=2.3.5 <2.4.0": "MAGECLOUD-5069__fpc_is_getting_disabled_during_deployments__2.3.5.patch"
     },
     "Sitemap Generation Warnings": {
-      "2.3.3": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
+      ">=2.3.3 <2.3.5": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
     }
   },
   "magento/module-paypal": {

--- a/patches.json
+++ b/patches.json
@@ -238,6 +238,9 @@
     },
     "Fix PayPal issue with region": {
       "100.3.4": "MC-31387__fix_paypal_issue_with_region__100.3.4.patch"
+    },
+    "Sitemap Generation Warnings": {
+      "2.3.3": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
     }
   },
   "magento/module-authorizenet": {

--- a/patches.json
+++ b/patches.json
@@ -235,7 +235,7 @@
       ">=2.3.3 <2.3.6": "MCLOUD-5650__hold_deployment_config_after_reading_from_file.patch"
     },
     "Sitemap Generation Warnings": {
-      ">=2.3.1 <2.3.5": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
+      ">=2.3.0 <2.3.5": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
     }
   },
   "magento/module-paypal": {

--- a/patches.json
+++ b/patches.json
@@ -230,6 +230,9 @@
     "FPC is getting disabled during deployments": {
       ">=2.3.2 <2.3.5": "MAGECLOUD-5069__fpc_is_getting_disabled_during_deployments__2.3.2.patch",
       ">=2.3.5 <2.4.0": "MAGECLOUD-5069__fpc_is_getting_disabled_during_deployments__2.3.5.patch"
+    },
+    "Sitemap Generation Warnings": {
+      "2.3.3": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
     }
   },
   "magento/module-paypal": {
@@ -238,9 +241,6 @@
     },
     "Fix PayPal issue with region": {
       "100.3.4": "MC-31387__fix_paypal_issue_with_region__100.3.4.patch"
-    },
-    "Sitemap Generation Warnings": {
-      "2.3.3": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
     }
   },
   "magento/module-authorizenet": {

--- a/patches.json
+++ b/patches.json
@@ -231,11 +231,11 @@
       ">=2.3.2 <2.3.5": "MAGECLOUD-5069__fpc_is_getting_disabled_during_deployments__2.3.2.patch",
       ">=2.3.5 <2.4.0": "MAGECLOUD-5069__fpc_is_getting_disabled_during_deployments__2.3.5.patch"
     },
-    "Sitemap Generation Warnings": {
-      ">=2.3.3 <2.3.5": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
-    },
     "Hold deployment config after reading from file": {
       ">=2.3.3 <2.3.6": "MCLOUD-5650__hold_deployment_config_after_reading_from_file.patch"
+    },
+    "Sitemap Generation Warnings": {
+      ">=2.3.1 <2.3.5": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
     }
   },
   "magento/module-paypal": {

--- a/patches.json
+++ b/patches.json
@@ -239,7 +239,8 @@
       ">=2.3.4 <2.4.0": "MCLOUD-5684__pagination_not_working_product_list_limit_all__2.3.4.patch"
     },
     "Sitemap Generation Warnings": {
-      ">=2.3.0 <2.3.5": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
+      ">=2.3.0 <2.3.2": "MCLOUD-3025__sitemap_generation_warnings__2.3.0.patch",
+      ">=2.3.2 <2.3.5": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
     }
   },
   "magento/module-paypal": {

--- a/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.0.patch
+++ b/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.0.patch
@@ -1,0 +1,155 @@
+diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/module-sitemap/Model/Observer.php
+--- a/vendor/magento/module-sitemap/Model/Observer.php
++++ b/vendor/magento/module-sitemap/Model/Observer.php
+@@ -5,6 +5,9 @@
+  */
+ namespace Magento\Sitemap\Model;
+
++use Magento\Framework\App\ObjectManager;
++use Psr\Log\LoggerInterface;
++
+ /**
+  * Sitemap module observer
+  *
+@@ -66,25 +69,38 @@ class Observer
+      */
+     protected $inlineTranslation;
+
++    /**
++     * @var int
++     */
++    private $retryInterval = 10;
++
++    /**
++     * @var LoggerInterface
++     */
++    private $logger;
++
+     /**
+      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+      * @param \Magento\Sitemap\Model\ResourceModel\Sitemap\CollectionFactory $collectionFactory
+      * @param \Magento\Store\Model\StoreManagerInterface $storeManager
+      * @param \Magento\Framework\Mail\Template\TransportBuilder $transportBuilder
+      * @param \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation
++     * @param LoggerInterface|null $logger
+      */
+     public function __construct(
+         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
+         \Magento\Sitemap\Model\ResourceModel\Sitemap\CollectionFactory $collectionFactory,
+         \Magento\Store\Model\StoreManagerInterface $storeManager,
+         \Magento\Framework\Mail\Template\TransportBuilder $transportBuilder,
+-        \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation
++        \Magento\Framework\Translate\Inline\StateInterface $inlineTranslation,
++        LoggerInterface $logger = null
+     ) {
+         $this->_scopeConfig = $scopeConfig;
+         $this->_collectionFactory = $collectionFactory;
+         $this->_storeManager = $storeManager;
+         $this->_transportBuilder = $transportBuilder;
+         $this->inlineTranslation = $inlineTranslation;
++        $this->logger = $logger ?: ObjectManager::getInstance()->get(LoggerInterface::class);
+     }
+
+     /**
+@@ -97,6 +113,7 @@ class Observer
+     public function scheduledGenerateSitemaps()
+     {
+         $errors = [];
++        $sitemapsWithError = [];
+
+         // check if scheduled generation enabled
+         if (!$this->_scopeConfig->isSetFlag(
+@@ -114,6 +131,7 @@ class Observer
+             try {
+                 $sitemap->generateXml();
+             } catch (\Exception $e) {
++                $sitemapsWithError[] = $sitemap;
+                 $errors[] = $e->getMessage();
+             }
+         }
+@@ -123,35 +141,56 @@ class Observer
+             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+         )
+         ) {
+-            $this->inlineTranslation->suspend();
+-
+-            $this->_transportBuilder->setTemplateIdentifier(
+-                $this->_scopeConfig->getValue(
+-                    self::XML_PATH_ERROR_TEMPLATE,
+-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+-                )
+-            )->setTemplateOptions(
+-                [
+-                    'area' => \Magento\Backend\App\Area\FrontNameResolver::AREA_CODE,
+-                    'store' => \Magento\Store\Model\Store::DEFAULT_STORE_ID,
+-                ]
+-            )->setTemplateVars(
+-                ['warnings' => join("\n", $errors)]
+-            )->setFrom(
+-                $this->_scopeConfig->getValue(
+-                    self::XML_PATH_ERROR_IDENTITY,
+-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+-                )
+-            )->addTo(
+-                $this->_scopeConfig->getValue(
+-                    self::XML_PATH_ERROR_RECIPIENT,
+-                    \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+-                )
+-            );
+-            $transport = $this->_transportBuilder->getTransport();
+-            $transport->sendMessage();
+-
+-            $this->inlineTranslation->resume();
++            sleep($this->retryInterval);
++            $message = 'Sitemap generation errors occurred: ';
++            $message .= join(';', $errors);
++            $this->logger->debug($message);
++            $this->logger->debug('Sitemap generation retry attempt');
++            $nonRecoverableErrors = [];
++            //re-try to write sitemap again
++            foreach ($sitemapsWithError as $sitemap) {
++                try {
++                    $sitemap->generateXml();
++                } catch (\Exception $e) {
++                    $nonRecoverableErrors[] = $e->getMessage();
++                }
++            }
++
++            if (!empty($nonRecoverableErrors)) {
++                $this->inlineTranslation->suspend();
++
++                $this->_transportBuilder->setTemplateIdentifier(
++                    $this->_scopeConfig->getValue(
++                        self::XML_PATH_ERROR_TEMPLATE,
++                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
++                    )
++                )->setTemplateOptions(
++                    [
++                        'area' => \Magento\Backend\App\Area\FrontNameResolver::AREA_CODE,
++                        'store' => \Magento\Store\Model\Store::DEFAULT_STORE_ID,
++                    ]
++                )->setTemplateVars(
++                    ['warnings' => join("\n", $nonRecoverableErrors)]
++                )->setFrom(
++                    $this->_scopeConfig->getValue(
++                        self::XML_PATH_ERROR_IDENTITY,
++                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
++                    )
++                )->addTo(
++                    $this->_scopeConfig->getValue(
++                        self::XML_PATH_ERROR_RECIPIENT,
++                        \Magento\Store\Model\ScopeInterface::SCOPE_STORE
++                    )
++                );
++                $transport = $this->_transportBuilder->getTransport();
++                $transport->sendMessage();
++
++                $this->inlineTranslation->resume();
++
++                $message = 'Sitemap generation non-recoverable errors occurred: ';
++                $message .= join(';', $nonRecoverableErrors);
++                $this->logger->debug($message);
++            }
+         }
+     }
+ }

--- a/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
+++ b/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
@@ -76,6 +76,5 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
 +            }
 +            $this->emailNotification->sendErrors($nonRecoverableErrors);
          }
-+
      }
  }

--- a/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
+++ b/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
@@ -1,19 +1,50 @@
 diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/module-sitemap/Model/Observer.php
 --- a/vendor/magento/module-sitemap/Model/Observer.php
 +++ b/vendor/magento/module-sitemap/Model/Observer.php
-@@ -61,6 +61,11 @@ class Observer
+@@ -9,6 +9,7 @@ use Magento\Sitemap\Model\EmailNotification as SitemapEmail;
+ use Magento\Framework\App\Config\ScopeConfigInterface;
+ use Magento\Sitemap\Model\ResourceModel\Sitemap\CollectionFactory;
+ use Magento\Store\Model\ScopeInterface;
++use Psr\Log\LoggerInterface;
+
+ /**
+  * Sitemap module observer
+@@ -61,20 +62,33 @@ class Observer
       */
      private $emailNotification;
- 
+
 +    /**
 +     * @var int
 +     */
 +    private $retryInterval = 10;
 +
++    /**
++     * @var LoggerInterface
++     */
++    private $logger;
++
      /**
       * Observer constructor.
       * @param ScopeConfigInterface $scopeConfig
-@@ -87,6 +92,7 @@ class Observer
+      * @param CollectionFactory $collectionFactory
+      * @param EmailNotification $emailNotification
++     * @param LoggerInterface $logger
+      */
+     public function __construct(
+         ScopeConfigInterface $scopeConfig,
+         CollectionFactory $collectionFactory,
+-        SitemapEmail $emailNotification
++        SitemapEmail $emailNotification,
++        LoggerInterface $logger
+     ) {
+         $this->scopeConfig = $scopeConfig;
+         $this->collectionFactory = $collectionFactory;
+         $this->emailNotification = $emailNotification;
++        $this->logger = $logger;
+     }
+
+     /**
+@@ -87,6 +101,7 @@ class Observer
      public function scheduledGenerateSitemaps()
      {
          $errors = [];
@@ -21,7 +52,7 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
          $recipient = $this->scopeConfig->getValue(
              Observer::XML_PATH_ERROR_RECIPIENT,
              ScopeInterface::SCOPE_STORE
-@@ -107,11 +113,22 @@ class Observer
+@@ -107,11 +122,25 @@ class Observer
              try {
                  $sitemap->generateXml();
              } catch (\Exception $e) {
@@ -29,10 +60,11 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
                  $errors[] = $e->getMessage();
              }
          }
--        if ($errors && $recipient) {
++
+         if ($errors && $recipient) {
 -            $this->emailNotification->sendErrors($errors);
-+        if ($errors && $recipient && !empty($sitemapsWithError)) {
 +            sleep($this->retryInterval);
++            $this->logger->debug('Sitemap generation retry occurred');
 +            $nonRecoverableErrors = [];
 +            //re-try to write sitemap again
 +            foreach ($sitemapsWithError as $sitemap) {
@@ -44,5 +76,6 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
 +            }
 +            $this->emailNotification->sendErrors($nonRecoverableErrors);
          }
++
      }
  }

--- a/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
+++ b/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
@@ -1,15 +1,18 @@
 diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/module-sitemap/Model/Observer.php
 --- a/vendor/magento/module-sitemap/Model/Observer.php
 +++ b/vendor/magento/module-sitemap/Model/Observer.php
-@@ -9,6 +9,7 @@ use Magento\Sitemap\Model\EmailNotification as SitemapEmail;
+@@ -7,8 +7,10 @@ namespace Magento\Sitemap\Model;
+
+ use Magento\Sitemap\Model\EmailNotification as SitemapEmail;
  use Magento\Framework\App\Config\ScopeConfigInterface;
++use Magento\Framework\App\ObjectManager;
  use Magento\Sitemap\Model\ResourceModel\Sitemap\CollectionFactory;
  use Magento\Store\Model\ScopeInterface;
 +use Psr\Log\LoggerInterface;
 
  /**
   * Sitemap module observer
-@@ -61,20 +62,33 @@ class Observer
+@@ -61,20 +63,33 @@ class Observer
       */
      private $emailNotification;
 
@@ -28,23 +31,23 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
       * @param ScopeConfigInterface $scopeConfig
       * @param CollectionFactory $collectionFactory
       * @param EmailNotification $emailNotification
-+     * @param LoggerInterface $logger
++     * @param LoggerInterface|null $logger
       */
      public function __construct(
          ScopeConfigInterface $scopeConfig,
          CollectionFactory $collectionFactory,
 -        SitemapEmail $emailNotification
 +        SitemapEmail $emailNotification,
-+        LoggerInterface $logger
++        LoggerInterface $logger = null
      ) {
          $this->scopeConfig = $scopeConfig;
          $this->collectionFactory = $collectionFactory;
          $this->emailNotification = $emailNotification;
-+        $this->logger = $logger;
++        $this->logger = $logger ?: ObjectManager::getInstance()->get(LoggerInterface::class);
      }
 
      /**
-@@ -87,6 +101,7 @@ class Observer
+@@ -87,6 +102,7 @@ class Observer
      public function scheduledGenerateSitemaps()
      {
          $errors = [];
@@ -52,7 +55,7 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
          $recipient = $this->scopeConfig->getValue(
              Observer::XML_PATH_ERROR_RECIPIENT,
              ScopeInterface::SCOPE_STORE
-@@ -107,11 +122,25 @@ class Observer
+@@ -107,11 +123,25 @@ class Observer
              try {
                  $sitemap->generateXml();
              } catch (\Exception $e) {
@@ -76,5 +79,6 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
 +            }
 +            $this->emailNotification->sendErrors($nonRecoverableErrors);
          }
++
      }
  }

--- a/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
+++ b/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
@@ -1,0 +1,48 @@
+diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/module-sitemap/Model/Observer.php
+--- a/vendor/magento/module-sitemap/Model/Observer.php
++++ b/vendor/magento/module-sitemap/Model/Observer.php
+@@ -61,6 +61,11 @@ class Observer
+      */
+     private $emailNotification;
+ 
++    /**
++     * @var int
++     */
++    private $retryInterval = 10;
++
+     /**
+      * Observer constructor.
+      * @param ScopeConfigInterface $scopeConfig
+@@ -87,6 +92,7 @@ class Observer
+     public function scheduledGenerateSitemaps()
+     {
+         $errors = [];
++        $sitemapsWithError = [];
+         $recipient = $this->scopeConfig->getValue(
+             Observer::XML_PATH_ERROR_RECIPIENT,
+             ScopeInterface::SCOPE_STORE
+@@ -107,11 +113,22 @@ class Observer
+             try {
+                 $sitemap->generateXml();
+             } catch (\Exception $e) {
++                $sitemapsWithError[] = $sitemap;
+                 $errors[] = $e->getMessage();
+             }
+         }
+-        if ($errors && $recipient) {
+-            $this->emailNotification->sendErrors($errors);
++        if ($errors && $recipient && !empty($sitemapsWithError)) {
++            sleep($this->retryInterval);
++            $nonRecoverableErrors = [];
++            //re-try to write sitemap again
++            foreach ($sitemapsWithError as $sitemap) {
++                try {
++                    $sitemap->generateXml();
++                } catch (\Exception $e) {
++                    $nonRecoverableErrors[] = $e->getMessage();
++                }
++            }
++            $this->emailNotification->sendErrors($nonRecoverableErrors);
+         }
+     }
+ }

--- a/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
+++ b/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
@@ -79,3 +79,4 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
 +
      }
  }
+

--- a/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
+++ b/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
@@ -79,4 +79,3 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
 +
      }
  }
-

--- a/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
+++ b/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
@@ -55,7 +55,7 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
          $recipient = $this->scopeConfig->getValue(
              Observer::XML_PATH_ERROR_RECIPIENT,
              ScopeInterface::SCOPE_STORE
-@@ -107,11 +123,31 @@ class Observer
+@@ -107,11 +123,33 @@ class Observer
              try {
                  $sitemap->generateXml();
              } catch (\Exception $e) {
@@ -80,10 +80,12 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
 +                    $nonRecoverableErrors[] = $e->getMessage();
 +                }
 +            }
-+            $this->emailNotification->sendErrors($nonRecoverableErrors);
-+            $message = 'Sitemap generation non-recoverable errors occurred: ';
-+            $message .= join(';', $nonRecoverableErrors);
-+            $this->logger->debug($message);
++            if (!empty($nonRecoverableErrors)) {
++                $this->emailNotification->sendErrors($nonRecoverableErrors);
++                $message = 'Sitemap generation non-recoverable errors occurred: ';
++                $message .= join(';', $nonRecoverableErrors);
++                $this->logger->debug($message);
++            }
          }
 +
      }

--- a/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
+++ b/patches/MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch
@@ -55,7 +55,7 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
          $recipient = $this->scopeConfig->getValue(
              Observer::XML_PATH_ERROR_RECIPIENT,
              ScopeInterface::SCOPE_STORE
-@@ -107,11 +123,25 @@ class Observer
+@@ -107,11 +123,31 @@ class Observer
              try {
                  $sitemap->generateXml();
              } catch (\Exception $e) {
@@ -67,7 +67,10 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
          if ($errors && $recipient) {
 -            $this->emailNotification->sendErrors($errors);
 +            sleep($this->retryInterval);
-+            $this->logger->debug('Sitemap generation retry occurred');
++            $message = 'Sitemap generation errors occurred: ';
++            $message .= join(';', $errors);
++            $this->logger->debug($message);
++            $this->logger->debug('Sitemap generation retry attempt');
 +            $nonRecoverableErrors = [];
 +            //re-try to write sitemap again
 +            foreach ($sitemapsWithError as $sitemap) {
@@ -78,6 +81,9 @@ diff -Nuar a/vendor/magento/module-sitemap/Model/Observer.php b/vendor/magento/m
 +                }
 +            }
 +            $this->emailNotification->sendErrors($nonRecoverableErrors);
++            $message = 'Sitemap generation non-recoverable errors occurred: ';
++            $message .= join(';', $nonRecoverableErrors);
++            $this->logger->debug($message);
          }
 +
      }


### PR DESCRIPTION
Fix for preventing sitemap generation warnings

### Description


### Fixed Issues (if relevant)
1. https://jira.corp.magento.com/browse/MCLOUD-3025

### Manual testing scenarios
Check that background sitemap generation still working as expected

**Negative test scenario**

Change the fs access right to read only fro the folder with sitemaps. After cron job run check that debug logs contains generation errors and retry attempts

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)

releasenotes
Added retry attempt when errors occur during sitemap generation to skip customer email notification in cases where errors can be recovered automatically.
