### PR TITLE
MCLOUD-5771: Redis out of memory on integration environments

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -241,6 +241,11 @@
     "Sitemap Generation Warnings": {
       ">=2.3.0 <2.3.2": "MCLOUD-3025__sitemap_generation_warnings__2.3.0.patch",
       ">=2.3.2 <2.3.5": "MCLOUD-3025__sitemap_generation_warnings__2.3.3.patch"
+    },
+    "Failure tolerance Redis cache backend": {
+      ">=2.3.0 <2.3.5": "MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.0.patch",
+      ">=2.3.5 <2.3.6": "MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.5.patch",
+      ">=2.3.0 <2.4.0": "MCLOUD-5771__change_redis_cache_adapter__2.3.x.patch"
     }
   },
   "magento/module-paypal": {

--- a/patches/MCLOUD-5771__change_redis_cache_adapter__2.3.x.patch
+++ b/patches/MCLOUD-5771__change_redis_cache_adapter__2.3.x.patch
@@ -1,0 +1,24 @@
+diff -Naur a/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php b/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
+--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
++++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/Cache.php
+@@ -20,7 +20,7 @@ use Magento\Setup\Validator\RedisConnectionValidator;
+ class Cache implements ConfigOptionsListInterface
+ {
+     const INPUT_VALUE_CACHE_REDIS = 'redis';
+-    const CONFIG_VALUE_CACHE_REDIS = 'Cm_Cache_Backend_Redis';
++    const CONFIG_VALUE_CACHE_REDIS = '\\Magento\\Framework\\Cache\\Backend\Redis';
+
+     const INPUT_KEY_CACHE_BACKEND = 'cache-backend';
+     const INPUT_KEY_CACHE_BACKEND_REDIS_SERVER = 'cache-backend-redis-server';
+diff -Naur a/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php b/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
+--- a/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
++++ b/setup/src/Magento/Setup/Model/ConfigOptionsList/PageCache.php
+@@ -20,7 +20,7 @@ use Magento\Setup\Validator\RedisConnectionValidator;
+ class PageCache implements ConfigOptionsListInterface
+ {
+     const INPUT_VALUE_PAGE_CACHE_REDIS = 'redis';
+-    const CONFIG_VALUE_PAGE_CACHE_REDIS = 'Cm_Cache_Backend_Redis';
++    const CONFIG_VALUE_PAGE_CACHE_REDIS = '\\Magento\\Framework\\Cache\\Backend\Redis';
+ 
+     const INPUT_KEY_PAGE_CACHE_BACKEND = 'page-cache';
+     const INPUT_KEY_PAGE_CACHE_BACKEND_REDIS_SERVER = 'page-cache-redis-server';

--- a/patches/MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.0.patch
+++ b/patches/MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.0.patch
@@ -1,0 +1,102 @@
+diff -Naur a/lib/internal/Magento/Framework/Cache/Backend/Redis.php b/lib/internal/Magento/Framework/Cache/Backend/Redis.php
+new file mode 100644
+--- /dev/null
++++ b/lib/internal/Magento/Framework/Cache/Backend/Redis.php
+@@ -0,0 +1,97 @@
++<?php
++/**
++ * Copyright © Magento, Inc. All rights reserved.
++ * See COPYING.txt for license details.
++ */
++
++namespace Magento\Framework\Cache\Backend;
++
++/**
++ * Redis wrapper to extend current implementation behaviour.
++ */
++class Redis extends \Cm_Cache_Backend_Redis
++{
++    /**
++     * Local state of preloaded keys.
++     *
++     * @var array
++     */
++    private $preloadedData = [];
++
++    /**
++     * Array of keys to be preloaded.
++     *
++     * @var array
++     */
++    private $preloadKeys = [];
++
++    /**
++     * @param array $options
++     */
++    public function __construct($options = [])
++    {
++        $this->preloadKeys = $options['preload_keys'] ?? [];
++        parent::__construct($options);
++    }
++
++    /**
++     * Load value with given id from cache
++     *
++     * @param  string  $id                     Cache id
++     * @param  boolean $doNotTestCacheValidity If set to true, the cache validity won't be tested
++     * @return bool|string
++     */
++    public function load($id, $doNotTestCacheValidity = false)
++    {
++        if (!empty($this->preloadKeys) && empty($this->preloadedData)) {
++            $redis =  $this->_slave ?? $this->_redis;
++            $redis = $redis->pipeline();
++
++            foreach ($this->preloadKeys as $key) {
++                $redis->hGet(self::PREFIX_KEY . $key, self::FIELD_DATA);
++            }
++
++            $this->preloadedData = array_filter(array_combine($this->preloadKeys, $redis->exec()));
++        }
++
++        if (isset($this->preloadedData[$id])) {
++            return $this->_decodeData($this->preloadedData[$id]);
++        }
++
++        return parent::load($id, $doNotTestCacheValidity);
++    }
++
++    /**
++     * Cover errors on save operations, which may occurs when Redis cannot evict keys, which is expected in some cases.
++     *
++     * @param string $data
++     * @param string $id
++     * @param array $tags
++     * @param bool $specificLifetime
++     * @return bool
++     */
++    public function save($data, $id, $tags = [], $specificLifetime = false)
++    {
++        try {
++            $result = parent::save($data, $id, $tags, $specificLifetime);
++        } catch (\Throwable $exception) {
++            $result = false;
++        }
++
++        return $result;
++    }
++
++    /**
++     * @inheritDoc
++     */
++    public function remove($id)
++    {
++        try {
++            $result = parent::remove($id);
++        } catch (\Throwable $exception) {
++            $result = false;
++        }
++
++        return $result;
++    }
++}

--- a/patches/MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.0.patch
+++ b/patches/MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.0.patch
@@ -1,7 +1,7 @@
-diff -Naur a/lib/internal/Magento/Framework/Cache/Backend/Redis.php b/lib/internal/Magento/Framework/Cache/Backend/Redis.php
+diff -Naur a/vendor/magento/framework/Cache/Backend/Redis.php b/vendor/magento/framework/Cache/Backend/Redis.php
 new file mode 100644
 --- /dev/null
-+++ b/lib/internal/Magento/Framework/Cache/Backend/Redis.php
++++ b/vendor/magento/framework/Cache/Backend/Redis.php
 @@ -0,0 +1,97 @@
 +<?php
 +/**

--- a/patches/MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.5.patch
+++ b/patches/MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.5.patch
@@ -10,8 +10,8 @@ diff -Naur a/vendor/magento/framework/Cache/Backend/Redis.php b/vendor/magento/f
          } catch (\Throwable $exception) {
 -            return false;
 +            $result = false;
-         }  
-
+         }
+ 
 -        return true;
 +        return $result;
 +    }

--- a/patches/MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.5.patch
+++ b/patches/MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.5.patch
@@ -1,0 +1,32 @@
+diff -Naur a/lib/internal/Magento/Framework/Cache/Backend/Redis.php b/lib/internal/Magento/Framework/Cache/Backend/Redis.php
+--- a/lib/internal/Magento/Framework/Cache/Backend/Redis.php
++++ b/lib/internal/Magento/Framework/Cache/Backend/Redis.php
+@@ -73,11 +73,25 @@ class Redis extends \Cm_Cache_Backend_Redis
+     public function save($data, $id, $tags = [], $specificLifetime = false)
+     {
+         try {
+-            parent::save($data, $id, $tags, $specificLifetime);
++            $result = parent::save($data, $id, $tags, $specificLifetime);
+         } catch (\Throwable $exception) {
+-            return false;
++            $result = false;
+         }  
+
+-        return true;
++        return $result;
++    }
++
++    /**
++     * @inheritDoc
++     */
++    public function remove($id)
++    {
++        try {
++            $result = parent::remove($id);
++        } catch (\Throwable $exception) {
++            $result = false;
++        }
++
++        return $result;
+     }
+ }

--- a/patches/MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.5.patch
+++ b/patches/MCLOUD-5771__failure_tolerance_redis_cache_backend__2.3.5.patch
@@ -1,6 +1,6 @@
-diff -Naur a/lib/internal/Magento/Framework/Cache/Backend/Redis.php b/lib/internal/Magento/Framework/Cache/Backend/Redis.php
---- a/lib/internal/Magento/Framework/Cache/Backend/Redis.php
-+++ b/lib/internal/Magento/Framework/Cache/Backend/Redis.php
+diff -Naur a/vendor/magento/framework/Cache/Backend/Redis.php b/vendor/magento/framework/Cache/Backend/Redis.php
+--- a/vendor/magento/framework/Cache/Backend/Redis.php
++++ b/vendor/magento/framework/Cache/Backend/Redis.php
 @@ -73,11 +73,25 @@ class Redis extends \Cm_Cache_Backend_Redis
      public function save($data, $id, $tags = [], $specificLifetime = false)
      {


### PR DESCRIPTION
### Description
Magento fails with the following errors if Redis has used all allocated memory:

> report.CRITICAL: OOM command not allowed when used memory > 'maxmemory'. {"exception":"[object] (CredisException(code: 0): OOM command not allowed when used memory > 'maxmemory'. at /app/vendor/colinmollenhour/credis/Client.php:1197, CredisException(code: 0): OOM command not allowed when used memory > 'maxmemory'. at /app/vendor/colinmollenhour/credis/Client.php:1157, RedisException(code: 0): OOM command not allowed when used memory > 'maxmemory'. at /app/vendor/colinmollenhour/credis/Client.php:1119)"} []

Since eviction mechanism in Redis doesn't guarantee 100% eviction rate we need to cover this case.

### Fixed Issues (if relevant)
https://jira.corp.magento.com/browse/MCLOUD-5771

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
