### PR TITLE
MAGECLOUD-6029: Implement New Relic Logs in Context

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -266,7 +266,8 @@
   },
   "monolog/monolog": {
     "Fix monolog Slack Handler bug for magento 2.1.x": {
-      "1.16.0": "MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch"
+      "1.16.0": "MAGECLOUD-2793__fix_monolog_slack_handler_2.1.x.patch",
+      ">=1.16.0 <1.24.0": "MAGECLOUD-6029__add_processor_interface_2.1.x.patch"
     }
   },
   "colinmollenhour/cache-backend-redis": {

--- a/patches/MAGECLOUD-6029__add_processor_interface_2.1.x.patch
+++ b/patches/MAGECLOUD-6029__add_processor_interface_2.1.x.patch
@@ -1,0 +1,29 @@
+diff -Naur a/vendor/monolog/monolog/src/Monolog/Processor/ProcessorInterface.php b/vendor/monolog/monolog/src/Monolog/Processor/ProcessorInterface.php
+--- /dev/null
++++ b/vendor/monolog/monolog/src/Monolog/Processor/ProcessorInterface.php
+@@ -0,0 +1,25 @@
++<?php
++
++/*
++ * This file is part of the Monolog package.
++ *
++ * (c) Jordi Boggiano <j.boggiano@seld.be>
++ *
++ * For the full copyright and license information, please view the LICENSE
++ * file that was distributed with this source code.
++ */
++
++namespace Monolog\Processor;
++
++/**
++ * An optional interface to allow labelling Monolog processors.
++ *
++ * @author Nicolas Grekas <p@tchwork.com>
++ */
++interface ProcessorInterface
++{
++    /**
++     * @return array The processed records
++     */
++    public function __invoke(array $records);
++}


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Adds patch to backport ProcessorInterface that was not introduced until Monolog 1.24.0.  ProcessorInterface is necessary to use the New Relic log enricher but Magento 2.1 has a hard requirement on Monolog 1.16.0

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud-patches#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. MCLOUD-6029

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Setup a cloud project with Magento 2.1.16
2. Require magento/magento-cloud-components with the same name
3. Test with current develop branch of ECE-tools
    1. This is necessary as the next release will move the patching to occur before di:compile
Expected result: Deploy occurs successfully

Without this change, the build will fail during di:compile

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
