### PR TITLE
MCLOUD-6682: B2B-716: Exception thrown during setup:upgrade when installing B2B

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -354,6 +354,9 @@
     },
     "Re-work consumers to terminate as soon as there is nothing left to process": {
       ">=2.2.0 <2.3.2": "MAGECLOUD-4071__terminate_consumers_if_the_queue_is_empty__2.2.0.patch"
+    },
+    "Fix of upgrade issue for b2b instances with more than 1 store": {
+      "2.4.0": "B2B-716-Exception_thrown_during_upgrade_when_installing_B2B_2.4.0.patch"
     }
   }
 }

--- a/patches/B2B-716-Exception_thrown_during_upgrade_when_installing_B2B_2.4.0.patch
+++ b/patches/B2B-716-Exception_thrown_during_upgrade_when_installing_B2B_2.4.0.patch
@@ -1,0 +1,21 @@
+diff --git a/app/code/Magento/PurchaseOrder/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php b/app/code/Magento/PurchaseOrder/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
+index c8acaa346..6579e8812 100644
+--- a/app/code/Magento/PurchaseOrder/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
++++ b/app/code/Magento/PurchaseOrder/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
+@@ -8,6 +8,7 @@ declare(strict_types=1);
+ namespace Magento\PurchaseOrder\Setup\Patch\Data;
+ 
+ use Magento\Framework\Setup\Patch\DataPatchInterface;
++use Magento\Framework\Setup\Patch\NonTransactionableInterface;
+ use Magento\SalesSequence\Model\Builder as SequenceBuilder;
+ use Magento\SalesSequence\Model\Config as SequenceConfig;
+ use Magento\Store\Api\StoreRepositoryInterface;
+@@ -15,7 +16,7 @@ use Magento\Store\Api\StoreRepositoryInterface;
+ /**
+  * Initializes purchase order sales sequence.
+  */
+-class InitPurchaseOrderSalesSequence implements DataPatchInterface
++class InitPurchaseOrderSalesSequence implements DataPatchInterface, NonTransactionableInterface
+ {
+     /**
+      * @var SequenceBuilder

--- a/patches/B2B-716-Exception_thrown_during_upgrade_when_installing_B2B_2.4.0.patch
+++ b/patches/B2B-716-Exception_thrown_during_upgrade_when_installing_B2B_2.4.0.patch
@@ -1,7 +1,7 @@
-diff --git a/app/code/Magento/PurchaseOrder/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php b/app/code/Magento/PurchaseOrder/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
+diff --git a/vendor/magento/module-purchase-order/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php b/vendor/magento/module-purchase-order/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
 index c8acaa346..6579e8812 100644
---- a/app/code/Magento/PurchaseOrder/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
-+++ b/app/code/Magento/PurchaseOrder/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
+--- a/vendor/magento/module-purchase-order/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
++++ b/vendor/magento/module-purchase-order/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
 @@ -8,6 +8,7 @@ declare(strict_types=1);
  namespace Magento\PurchaseOrder\Setup\Patch\Data;
  

--- a/patches/B2B-716-Exception_thrown_during_upgrade_when_installing_B2B_2.4.0.patch
+++ b/patches/B2B-716-Exception_thrown_during_upgrade_when_installing_B2B_2.4.0.patch
@@ -1,5 +1,4 @@
 diff --git a/vendor/magento/module-purchase-order/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php b/vendor/magento/module-purchase-order/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
-index c8acaa346..6579e8812 100644
 --- a/vendor/magento/module-purchase-order/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
 +++ b/vendor/magento/module-purchase-order/Setup/Patch/Data/InitPurchaseOrderSalesSequence.php
 @@ -8,6 +8,7 @@ declare(strict_types=1);


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
https://jira.corp.magento.com/browse/MCLOUD-6682:
Patch for https://jira.corp.magento.com/browse/B2B-716

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento-cloud-patches#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. https://jira.corp.magento.com/browse/B2B-716


### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. ...
2. ...

### Release notes

For user-facing changes, add a meaningful release note. For examples, see [Magento Cloud Patches release notes](https://devdocs.magento.com/cloud/release-notes/mcp-release-notes.html).

### Associated documentation updates
<!--
 If your proposed update requires user documentation, submit a PR to the Magento DevDocs repository. For extensive updates requiring assistance, submit an issue to DevDocs. See https://github.com/magento/devdocs/blob/master/.github/CONTRIBUTING.md.
 -->
Add link to Magento DevDocs PR or Issue, if needed.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] Pull request introduces user-facing changes and includes meaningful updates for any required release notes and documentation changes
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
