### PR TITLE
Restrict patch from being applied to version 2.4.3-p2. Since it's bee…

### DIFF
--- a/patches.json
+++ b/patches.json
@@ -383,7 +383,7 @@
     "Parser token new fix": {
       ">=2.3.3-p1 <=2.3.4": "MDVA-43443__parser_token_new_fix__2.3.3-p1.patch",
       ">=2.3.4-p2 <2.3.7-p4 || >=2.4.0 <2.4.3": "MDVA-43443__parser_token_new_fix__2.3.4-p2.patch",
-      ">=2.4.3 <2.4.3-p3": "MDVA-43443__parser_token_new_fix__2.4.3.patch"
+      ">=2.4.3 <2.4.3-p2": "MDVA-43443__parser_token_new_fix__2.4.3.patch"
     }
   }
 }


### PR DESCRIPTION
…n resolved in the patch it self.

For more information see:
* https://github.com/magento/magento2/issues/35341

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
Magento cloud patches apply a patch that has been resolved in magento 2.4.3-p2. According to @nathanjosiah. 

### Fixed Issues (if relevant)
1. Patch MDVA-43443__parser_token_new_fix__2.4.3.patch is not applied for 2.4.3-p2.

### Associated documentation updates
https://github.com/magento/magento2/issues/35341

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] Pull request introduces user-facing changes and includes meaningful updates for any required release notes and documentation changes
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
