### PR TITLE
Relax composer version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
         "ext-json": "*",
         "composer/composer": "@stable",
         "composer/semver": "@stable",
-        "symfony/config": "^3.3||^4.4||^5.1",
-        "symfony/console": "^2.6||^4.0||^5.1",
-        "symfony/dependency-injection": "^3.3||^4.3||^5.1",
-        "symfony/process": "^2.1||^4.1||^5.1",
-        "symfony/proxy-manager-bridge": "^3.3||^4.3||^5.1",
-        "symfony/yaml": "^3.3||^4.0||^5.1",
-        "monolog/monolog": "^1.25||^2.3",
-        "magento/quality-patches": "^1.1.0"
+        "magento/quality-patches": "^1.0",
+        "monolog/monolog": "^1.0 || ^2.0",
+        "symfony/config": "^3.0 || ^4.0 || ^5.0",
+        "symfony/console": "^2.0 || ^4.0 || ^5.0",
+        "symfony/dependency-injection": "^3.0 || ^4.0 || ^5.0",
+        "symfony/process": "^2.0 || ^4.0 || ^5.0",
+        "symfony/proxy-manager-bridge": "^3.0 || ^4.0 || ^5.0",
+        "symfony/yaml": "^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "codeception/codeception": "^4.1",


### PR DESCRIPTION
### Description
The version constraints currently listed in this package are more strict than necessary, and are causing issues elsewhere. I can't see anything in this package which actually depends on the specific feature versions that are being required. From what I can tell, these dependencies work just fine with the first release of each major version number and all subsequent versions.

### Fixed Issues (if relevant)
1. Fixes https://github.com/magento/quality-patches/issues/71
1. Fixes https://github.com/magento/quality-patches/issues/79

### Manual testing scenarios
1. Install this package with `--prefer-lowest` composer flag set.
1. Run test suite

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
