### PR TITLE
[FEATURE] Include custom patches metadata to be displayed in the "status" command

### DIFF
--- a/src/Command/Process/Renderer.php
+++ b/src/Command/Process/Renderer.php
@@ -225,7 +225,7 @@ class Renderer
             $details .= PHP_EOL . '<comment>Requirements:</comment>' . PHP_EOL . ' - ' . $requirements;
         }
 
-        $id = $patch->getType() === PatchInterface::TYPE_CUSTOM ? 'N/A' : $patch->getId();
+        $id = $patch->getId();
         $title = chunk_split($patch->getTitle(), 60, PHP_EOL);
 
         return [

--- a/src/Patch/Collector/LocalCollector.php
+++ b/src/Patch/Collector/LocalCollector.php
@@ -48,16 +48,21 @@ class LocalCollector
     public function collect(): array
     {
         $files = $this->sourceProvider->getLocalPatches();
+        $infoFile = $this->sourceProvider->getLocalPatchesConfig();
         $result = [];
         foreach ($files as $file) {
             $shortPath = '../' . SourceProvider::HOT_FIXES_DIR . '/' . basename($file);
-            $this->patchBuilder->setId($shortPath);
-            $this->patchBuilder->setTitle($shortPath);
+            $fileKey = basename($file);
+            $id = !empty($infoFile[$fileKey]['id']) ? $infoFile[$fileKey]['id'] : $fileKey;
+            $title = !empty($infoFile[$fileKey]['title']) ? $infoFile[$fileKey]['title'] : $shortPath;
+            $categories = !empty($infoFile[$fileKey]['categories']) ? $infoFile[$fileKey]['categories'] : ['Other'];
+            $this->patchBuilder->setId($id);
+            $this->patchBuilder->setTitle($title);
             $this->patchBuilder->setFilename(basename($file));
             $this->patchBuilder->setPath($file);
             $this->patchBuilder->setType(PatchInterface::TYPE_CUSTOM);
             $this->patchBuilder->setOrigin(self::ORIGIN);
-            $this->patchBuilder->setCategories(['Other']);
+            $this->patchBuilder->setCategories($categories);
             $result[] = $this->patchBuilder->build();
         }
 

--- a/src/Patch/SourceProvider.php
+++ b/src/Patch/SourceProvider.php
@@ -123,4 +123,34 @@ class SourceProvider
 
         return $files ?: [];
     }
+
+    /**
+     * Returns custom patches configuration from m2-hotfixes/custom-patches.json.
+     *
+     * The file is optional; an empty array is returned when it does not exist
+     * or cannot be parsed.
+     *
+     * Expected format:
+     * {
+     *   "MY-PATCH-001.patch": {
+     *     "id": "MY-PATCH-001",
+     *     "title": "My patch title",
+     *     "categories": ["Performance"]
+     *   }
+     * }
+     *
+     * @return array
+     */
+    public function getLocalPatchesConfig(): array
+    {
+        $configPath = $this->directoryList->getMagentoRoot()
+            . '/' . static::HOT_FIXES_DIR
+            . '/custom-patches.json';
+
+        try {
+            return $this->jsonConfigReader->read($configPath);
+        } catch (\Exception $e) {
+            return [];
+        }
+    }
 }

--- a/src/Test/Unit/Patch/Collector/LocalCollectorTest.php
+++ b/src/Test/Unit/Patch/Collector/LocalCollectorTest.php
@@ -51,7 +51,10 @@ class LocalCollectorTest extends TestCase
     }
 
     /**
-     * Tests collecting local patches.
+     * Tests collecting local patches without custom-patches.json (fallback behaviour).
+     *
+     * When no custom config is present the id falls back to basename($file) and
+     * the title falls back to the short relative path.
      *
      * @return void
      */
@@ -67,11 +70,19 @@ class LocalCollectorTest extends TestCase
             ->method('getLocalPatches')
             ->willReturn([$file1, $file2]);
 
+        // No custom config → empty array
+        $this->sourceProvider->expects($this->once())
+            ->method('getLocalPatchesConfig')
+            ->willReturn([]);
+
+        // Fallback id is basename($file), not the full short path
         $this->patchBuilder->expects($this->exactly(2))
             ->method('setId')
             ->with(
-                $this->logicalOr($this->equalTo($shortPath1), $this->equalTo($shortPath2))
+                $this->logicalOr($this->equalTo('patch1.patch'), $this->equalTo('patch2.patch'))
             );
+
+        // Fallback title is still the full short path
         $this->patchBuilder->expects($this->exactly(2))
             ->method('setTitle')
             ->with(
@@ -115,5 +126,67 @@ class LocalCollectorTest extends TestCase
             ->willReturn($this->createMock(Patch::class));
 
         $this->assertTrue(is_array($this->collector->collect()));
+    }
+
+    /**
+     * Tests collecting local patches with a custom-patches.json config.
+     *
+     * When custom config is provided the id, title and categories are read from it.
+     *
+     * @return void
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    public function testCollectWithCustomConfig(): void
+    {
+        $file1 = __DIR__ . SourceProvider::HOT_FIXES_DIR . '/patch1.patch';
+        $shortPath1 = '../' . SourceProvider::HOT_FIXES_DIR . '/patch1.patch';
+
+        $customConfig = [
+            'patch1.patch' => [
+                'id'         => 'HIB-000001',
+                'title'      => 'My custom patch title',
+                'categories' => ['Performance'],
+            ],
+        ];
+
+        $this->sourceProvider->expects($this->once())
+            ->method('getLocalPatches')
+            ->willReturn([$file1]);
+
+        $this->sourceProvider->expects($this->once())
+            ->method('getLocalPatchesConfig')
+            ->willReturn($customConfig);
+
+        $this->patchBuilder->expects($this->once())
+            ->method('setId')
+            ->with('HIB-000001');
+
+        $this->patchBuilder->expects($this->once())
+            ->method('setTitle')
+            ->with('My custom patch title');
+
+        $this->patchBuilder->expects($this->once())
+            ->method('setCategories')
+            ->with(['Performance']);
+
+        $this->patchBuilder->expects($this->once())
+            ->method('setFilename')
+            ->with('patch1.patch');
+
+        $this->patchBuilder->expects($this->once())
+            ->method('setPath')
+            ->with($file1);
+
+        $this->patchBuilder->expects($this->once())
+            ->method('setType')
+            ->with(PatchInterface::TYPE_CUSTOM);
+
+        $this->patchBuilder->expects($this->once())
+            ->method('build')
+            ->willReturn($this->createMock(Patch::class));
+
+        $result = $this->collector->collect();
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
     }
 }

--- a/src/Test/Unit/Patch/SourceProviderTest.php
+++ b/src/Test/Unit/Patch/SourceProviderTest.php
@@ -252,4 +252,57 @@ class SourceProviderTest extends TestCase
 
         $this->sourceProvider->getCommunityPatches();
     }
+
+    /**
+     * Tests retrieving local patches config when custom-patches.json exists.
+     *
+     * @return void
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    public function testGetLocalPatchesConfig(): void
+    {
+        $magentoRoot = '/magento/root';
+        $configPath = $magentoRoot . '/' . SourceProvider::HOT_FIXES_DIR . '/custom-patches.json';
+        $configSource = [
+            'HIB-000001.patch' => [
+                'id'         => 'HIB-000001',
+                'title'      => 'My custom fix',
+                'categories' => ['Bug Fix'],
+            ],
+        ];
+
+        $this->directoryList->expects($this->once())
+            ->method('getMagentoRoot')
+            ->willReturn($magentoRoot);
+
+        $this->jsonConfigReader->expects($this->once())
+            ->method('read')
+            ->with($configPath)
+            ->willReturn($configSource);
+
+        $this->assertEquals($configSource, $this->sourceProvider->getLocalPatchesConfig());
+    }
+
+    /**
+     * Tests that getLocalPatchesConfig returns empty array when file is missing.
+     *
+     * @return void
+     */
+    #[AllowMockObjectsWithoutExpectations]
+    public function testGetLocalPatchesConfigMissing(): void
+    {
+        $magentoRoot = '/magento/root';
+        $configPath = $magentoRoot . '/' . SourceProvider::HOT_FIXES_DIR . '/custom-patches.json';
+
+        $this->directoryList->expects($this->once())
+            ->method('getMagentoRoot')
+            ->willReturn($magentoRoot);
+
+        $this->jsonConfigReader->expects($this->once())
+            ->method('read')
+            ->with($configPath)
+            ->willThrowException(new SourceProviderException('File not found'));
+
+        $this->assertEquals([], $this->sourceProvider->getLocalPatchesConfig());
+    }
 }


### PR DESCRIPTION
## Overview

This PR adds support for custom patch metadata through `m2-hotfixes/custom-patches.json`.

The goal is to allow custom patches to define their own ID, title, and categories while keeping full backwards compatibility with existing projects that do not use this configuration file.

## Changes implemented

### 1. `src/Patch/SourceProvider.php`

* Added a new `getLocalPatchesConfig()` method.
* The method reads `m2-hotfixes/custom-patches.json` using the existing injected `DirectoryList` and `JsonConfigReader`.
* Returns an empty array when the file does not exist.
* No `custom-patches.json` file is required, so existing projects continue working unchanged.

### 2. `src/Patch/Collector/LocalCollector.php`

* Updated `collect()` to load patch metadata from `getLocalPatchesConfig()`.

* For each `.patch` file, the collector now checks if there is a matching entry in `custom-patches.json`.

* When metadata exists, it uses the configured:

  * `id`
  * `title`
  * `categories`

* When metadata is not found, it keeps the previous behaviour:

  * Filename is used as ID.
  * Filename is used as title.
  * Category defaults to `Other`.

No additional dependencies were introduced.

### 3. `src/Command/Process/Renderer.php`

* Removed the hard-coded `N/A` value for `TYPE_CUSTOM` patches.
* Custom patches now display their real ID in the `ece-patches status` table.
* The displayed ID comes from:

  * `custom-patches.json` when configured.
  * Filename fallback when no configuration exists.

## Usage example

Create `m2-hotfixes/custom-patches.json` next to your `.patch` files:

```json
{
    "HIB-000001.patch": {
        "id": "HIB-000001",
        "title": "Fix checkout crash on empty cart",
        "categories": ["Bug Fix"]
    },
    "HIB-000002.patch": {
        "id": "HIB-000002",
        "title": "Improve category page performance",
        "categories": ["Performance"]
    }
}
```

After adding this configuration, running `php ./vendor/bin/ece-patches status` will display the configured custom patch ID and title.

## Backwards compatibility

Existing custom patches without an entry in `custom-patches.json` continue to work exactly as before:

* ID: patch filename
* Title: patch filename
* Category: `Other`

No changes are required for current projects.

Example screenshots:

Before:

<img width="2172" height="724" alt="imagen" src="https://github.com/user-attachments/assets/071f1270-0d4f-40a4-8eb0-4388d47b9c0f" />


After:

<img width="2170" height="725" alt="imagen" src="https://github.com/user-attachments/assets/997648ba-363c-4304-8bc2-f32a9a1657ce" />
